### PR TITLE
データベース設計の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Things you may want to cover:
 |ship_date|integer|null: false|
 |price|integer|null: false|
 |brand|string||
-|buyer_id|references|foreign_key:true
+|buyer_id|references|foreign_key:true|
 |user_id|references|null: false, foreign_key: true|
 |category_id|references|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Things you may want to cover:
 |first_name_kana|string|null: false|
 |birthday|date|null: false|
 ### Association
- - has_many :products
+ - has_many :items
  - has_one :credit_card
  - has_one :address
 
@@ -67,7 +67,7 @@ Things you may want to cover:
 ### Association
  - belongs_to :user
 
-## productsテーブル
+## itemsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
@@ -78,6 +78,7 @@ Things you may want to cover:
 |ship_date|integer|null: false|
 |price|integer|null: false|
 |brand|string||
+|buyer_id|references|foreign_key:true
 |user_id|references|null: false, foreign_key: true|
 |category_id|references|null: false, foreign_key: true|
 ### Association
@@ -91,12 +92,12 @@ Things you may want to cover:
 |name|string|null: false|
 |ancestry|string||
 ### Association
- - has_many :products
+ - has_many :items
 
 ## imagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |image|string|null: false|
-|product_id|references|null: false, foreign_key: true|
+|item_id|references|null: false, foreign_key: true|
 ### Association
- - belongs_to :product
+ - belongs_to :item


### PR DESCRIPTION
# What
データベース設計の不備を修正する
取り扱う商品に関する名称を`products`から`items`へ変更
`itemsテーブル`に`buyer_idカラム`を追加

# Why
商品に関するコーディングをitemsで行っているため
修正前のデータベース設計では購入済み商品の非表示への対応が出来なかったため

ER図
<img width="763" alt="スクリーンショット 2020-10-21 22 00 41" src="https://user-images.githubusercontent.com/68369600/96723012-05c47180-13e9-11eb-9761-8b145cd52e4d.png">