### PR TITLE
パンくずリスト表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,4 @@ gem "aws-sdk-s3", require: false
 gem 'payjp'
 gem "jquery-rails"
 gem 'dotenv-rails'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.2.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
@@ -397,6 +400,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import "modules/done_transactions";
 @import "modules/flash";
 @import "modules/items-show";
+@import "modules/breadcrumb";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "modules/users-edit";
 @import "modules/users-show";
 @import "modules/users-favorites";
+@import "modules/users-listed_items";
 @import "modules/buy_transactions";
 @import "modules/done_transactions";
 @import "modules/flash";

--- a/app/assets/stylesheets/modules/_breadcrumb.scss
+++ b/app/assets/stylesheets/modules/_breadcrumb.scss
@@ -1,0 +1,20 @@
+.breadcrumbs{
+  font-size: 14px;
+  height: 40px;
+  width: 100vw;
+  padding: 0 17vw;
+  background-color: #fff;
+  line-height: 40px;
+  text-align: left;
+  a{
+    text-decoration: none;
+    color: black;
+  }
+  a:hover{
+    text-decoration: underline;
+    color: gray;
+  }
+  .current{
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/modules/_users-listed_items.scss
+++ b/app/assets/stylesheets/modules/_users-listed_items.scss
@@ -1,0 +1,21 @@
+.mypage-picupContents{
+  padding: 24px 0;
+  background-color: #f5f5f5;
+}
+.listed-title{
+  display: flex;
+  justify-content: center;
+  font-size: 24px;
+}
+.listed_items{
+  flex-wrap: wrap;
+  width: 780px;
+  margin: 26px auto;
+  display: flex;
+  justify-content: space-between;
+  .newList{
+    width: auto;
+    margin-bottom: 20px;
+    border: solid 1px gray;
+  }
+}

--- a/app/assets/stylesheets/modules/_users-listed_items.scss
+++ b/app/assets/stylesheets/modules/_users-listed_items.scss
@@ -16,6 +16,11 @@
   .newList{
     width: auto;
     margin-bottom: 20px;
-    border: solid 1px gray;
   }
+}
+
+.listed_items::after{
+  display: block;
+  content:"";
+  width: 220px;
 }

--- a/app/assets/stylesheets/modules/_users-show.scss
+++ b/app/assets/stylesheets/modules/_users-show.scss
@@ -8,7 +8,7 @@
 
 .show-main{
   display: flex;
-  height: 500px;
+  padding-bottom: 40px;
 }
 
 .sidebar{

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,4 +13,9 @@ class UsersController < ApplicationController
     favorites = Favorite.where(user_id: current_user.id).pluck(:item_id)
     @favorite_list = Item.find(favorites)
   end
+
+  def listed_items
+    @listed_items = Item.where(user_id: current_user.id)
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < ApplicationController
   def show 
     @user = User.find(params[:id])
-
     favorites = Favorite.where(user_id: current_user.id).pluck(:item_id)
     @favorite_list = Item.find(favorites)
   end
@@ -16,6 +15,10 @@ class UsersController < ApplicationController
 
   def listed_items
     @listed_items = Item.where(user_id: current_user.id)
+  end
+
+  def purchased_items
+    @purchased_items = Item.where(buyer_id: current_user.id)
   end
 
 end

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,1 @@
+= breadcrumbs separatior: " &rsaquo; "

--- a/app/views/users/favorites.html.haml
+++ b/app/views/users/favorites.html.haml
@@ -2,7 +2,7 @@
 - breadcrumb :favorite
 = render "layouts/breadcrumbs"
 .main-search
-  %section.picupContents
+  %section.mypage-picupContents
     .favorite-title お気に入り一覧
     .newBox
       .newLists

--- a/app/views/users/favorites.html.haml
+++ b/app/views/users/favorites.html.haml
@@ -1,4 +1,6 @@
 = render "items/header"
+- breadcrumb :favorite
+= render "layouts/breadcrumbs"
 .main-search
   %section.picupContents
     .favorite-title お気に入り一覧

--- a/app/views/users/favorites.html.haml
+++ b/app/views/users/favorites.html.haml
@@ -5,7 +5,7 @@
   %section.mypage-picupContents
     .favorite-title お気に入り一覧
     .newBox
-      .newLists
+      .listed_items
         - if @favorite_list.present?
           - @favorite_list.each do |item|
             .newList

--- a/app/views/users/listed_items.html.haml
+++ b/app/views/users/listed_items.html.haml
@@ -1,0 +1,25 @@
+.show-container
+  = render "items/header"
+  - breadcrumb :listed_items
+  = render "layouts/breadcrumbs"
+  .mypage-picupContents
+    .listed-title 出品した商品一覧
+    .listed_items
+      - @listed_items.each do |item|
+        .newList
+          = link_to item_path(item.id), class: "beef" do
+            %figure.newList--image
+              - item.images.first(1).each do |image|
+                = image_tag image, class: "meat"
+            .newList--body
+              %h3.name
+                = item.name
+              .details
+                %ul
+                  %li.foodPrice
+                    = item.price
+                  %li.star
+                .priceFurima
+                  (税込）
+  = render "items/footer"
+  = render "items/putup-btn" 

--- a/app/views/users/purchased_items.html.haml
+++ b/app/views/users/purchased_items.html.haml
@@ -1,0 +1,25 @@
+.show-container
+  = render "items/header"
+  - breadcrumb :purchased_items
+  = render "layouts/breadcrumbs"
+  .mypage-picupContents
+    .listed-title 購入した商品一覧
+    .listed_items
+      - @purchased_items.each do |item|
+        .newList
+          = link_to item_path(item.id), class: "beef" do
+            %figure.newList--image
+              - item.images.first(1).each do |image|
+                = image_tag image, class: "meat"
+            .newList--body
+              %h3.name
+                = item.name
+              .details
+                %ul
+                  %li.foodPrice
+                    = item.price
+                  %li.star
+                .priceFurima
+                  (税込）
+  = render "items/footer"
+  = render "items/putup-btn" 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,7 @@
 .show-container
   = render "items/header"
+  - breadcrumb :mypage
+  = render "layouts/breadcrumbs"
   .show-main
     .sidebar
       .menu

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,6 +18,8 @@
               %li 商品を出品する
             = link_to listed_items_users_path, class:"menu__list--btn" do
               %li 出品した商品
+            = link_to purchased_items_users_path, class:"menu__list--btn" do
+              %li 購入した商品
       .menu
         %h2.menu__title 設定・その他
         .menu__list

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -16,8 +16,8 @@
           %ul
             = link_to new_item_path, class:"menu__list--btn" do
               %li 商品を出品する
-            = link_to "#", class:"menu__list--btn" do
-              %li 購入した商品
+            = link_to listed_items_users_path, class:"menu__list--btn" do
+              %li 出品した商品
       .menu
         %h2.menu__title 設定・その他
         .menu__list

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -16,6 +16,10 @@ crumb :listed_items do
   parent :mypage
 end 
 
+crumb :purchased_items do
+  link "購入した商品一覧", purchased_items_users_path
+  parent :mypage
+end 
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -11,6 +11,11 @@ crumb :favorite do
   parent :mypage
 end
 
+crumb :listed_items do
+  link "出品した商品一覧", listed_items_users_path
+  parent :mypage
+end 
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,37 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", user_path(current_user.id)
+end
+
+crumb :favorite do
+  link "お気に入り一覧", favorites_users_path
+  parent :mypage
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -20,27 +20,3 @@ crumb :purchased_items do
   link "購入した商品一覧", purchased_items_users_path
   parent :mypage
 end 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'items/new'
   resources:users, only: [:show, :edit, :update] do
     get :favorites, on: :collection
+    get :listed_items, on: :collection
   end
 
   resources:credit_cards, only: [:new, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources:users, only: [:show, :edit, :update] do
     get :favorites, on: :collection
     get :listed_items, on: :collection
+    get :purchased_items, on: :collection
   end
 
   resources:credit_cards, only: [:new, :show] do


### PR DESCRIPTION
# What
パンくずリストをヘッダー下に表示する機能の実装

# Why
ユーザーが今どの階層のページにいるかを視覚的にわかるようにし、ページ移動を容易にするため

<a href="https://gyazo.com/4338fb9a23d8ffe55a88d275e00d54d3"><img src="https://i.gyazo.com/4338fb9a23d8ffe55a88d275e00d54d3.gif" alt="Image from Gyazo" width="1000"/></a>