### PR TITLE
編集ページ遷移後に紐づけられたカテゴリ情報が入力されている

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,6 +45,13 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+    parent_category = child_category.parent
+    @category_parent_array = Category.where(ancestry: parent_category.ancestry)
+    @category_children_array = Category.where(ancestry: child_category.ancestry)
+    @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
+
     if user_signed_in? && current_user.id == @item.user_id
       render :edit
     else

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -48,13 +48,13 @@
                 = f.label :カテゴリー ,class: "sell-box__detail__category"
                 %span.sell-box__require 必須
                 %br
-                = f.select :category_id ,[["選択してください", ""],["メンズ", 1], ["レディース", 2], ["キッズ", 3]], {},class: "sell-box__detail__form"
-                %br/
-
-                = f.select :childCategory ,[["選択してください", ""],["トップス", 1], ["ボトムス", 2], ["シューズ", 3]], {},class: "sell-box__detail__form"
-                %br/
-
-                = f.select :grandchildCategory ,[["選択してください", ""],["Tシャツ", 1], ["シャツ", 2], ["パーカー", 3]], {},class: "sell-box__detail__form"
+                .item_input__body__category#category_box
+                  .pulldown#partent_box
+                    = f.select :category_id, options_for_select( @category_parent_array.map{|c| [c[:name], c[:id]]},@item.category.parent.parent.id), {}, { class: "parent_category_box", id: "parent_category"}
+                  .pulldown.item_input__body__category__children#children_box
+                    = f.select :child_id, options_for_select(@category_children_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'item_input__body__category__children--select', id: 'children_category'}
+                  .pulldown.item_input__body__category__grandchildren#grandchildren_box
+                    = f.select :category_id, options_for_select(@category_grandchildren_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'item_input__body__category__grandchildren--select', id: 'grandchildren_category', name:"item[category_id]"}
                 .sell-box__detail__size
                 = f.label :サイズ ,class: "sell-box__detai__size"
                 %span.sell-box__require--any 任意

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -331,7 +331,3 @@ others_8 = others.children.create(name: "事務/店舗用品")
 others_8.children.create([{name: "オフィス用品一般"},{name: "オフィス家具"},{name: "店舗用品"},{name: "OA機器"},{name: "ラッピング/包装"},{name: "その他"}])
 others_9 = others.children.create(name: "その他")
 others_9.children.create([{name: "すべて"}])
-
-# カテゴリー一覧
-
-categories = Category.create(name: "カテゴリー一覧")


### PR DESCRIPTION
# What
編集ページに移動した際、商品に登録されている情報が全て入力されている状態にする

# Why
編集前の情報を確認できるようにし、必要な部分だけを編集できるようにするため

<a href="https://gyazo.com/b7ccfb8d9ae12385e792006ff6c2952f"><img src="https://i.gyazo.com/b7ccfb8d9ae12385e792006ff6c2952f.gif" alt="Image from Gyazo" width="1000"/></a>