### PR TITLE
商品詳細ページの修正

### DIFF
--- a/app/assets/stylesheets/modules/_items-show.scss
+++ b/app/assets/stylesheets/modules/_items-show.scss
@@ -255,7 +255,6 @@
         font-weight: bold;
         font-size: 22px;
         display: block;
-
       }
       .productList{
         margin: 0 10px;
@@ -311,4 +310,9 @@
     color: #fff;
     letter-spacing: 3px;
   }
+}
+
+.relatedBox {
+  display: flex;
+  justify-content: space-around;
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,8 +45,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if user_signed_in? && current_user.id == @item.user_id
-      render :edit
+    if @item.buyer_id.blank?
+      if user_signed_in? && current_user.id == @item.user_id
+        render :edit
+      else
+        redirect_to root_path
+      end
     else
       redirect_to root_path
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,9 +29,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @related_items = Item.limit(5).where(category: @item.category_id).
-      where.not(id: @item.id).order("id DESC")
-    # @related_items = Item.find(params[:id])
+    @related_items = Item.limit(3).where(category: @item.category_id).
+      where.not(id: @item.id).order("RAND()", "id DESC")
     @category_id = @item.category_id
     @category_grandchild = Category.find(@category_id)
     @category_child = @category_grandchild.parent
@@ -54,14 +53,10 @@ class ItemsController < ApplicationController
     @category_children_array = Category.where(ancestry: child_category.ancestry)
     @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
 
-    if @item.buyer_id.blank?
-      if user_signed_in? && current_user.id == @item.user_id
-        render :edit
-      else
-        redirect_to root_path
-      end
-    else 
-      redirect_to user_path(current_user.id), alert: '既に購入された商品です'
+    if user_signed_in? && current_user.id == @item.user_id && @item.buyer_id.blank?
+      render :edit
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @related_items = Item.find(params[:id])
+    # @related_items = Item.where(category_parent_array )
+    @related_items = Item.all
+    # @related_items = Item.find(params[:id])
     @category_id = @item.category_id
     @category_grandchild = Category.find(@category_id)
     @category_child = @category_grandchild.parent
@@ -51,7 +53,7 @@ class ItemsController < ApplicationController
     @category_parent_array = Category.where(ancestry: parent_category.ancestry)
     @category_children_array = Category.where(ancestry: child_category.ancestry)
     @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
-    
+
     if @item.buyer_id.blank?
       if user_signed_in? && current_user.id == @item.user_id
         render :edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,8 +29,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # @related_items = Item.where(category_parent_array )
-    @related_items = Item.all
+    @related_items = Item.limit(5).where(category: @item.category_id).
+      where.not(id: @item.id).order("id DESC")
     # @related_items = Item.find(params[:id])
     @category_id = @item.category_id
     @category_grandchild = Category.find(@category_id)
@@ -60,8 +60,8 @@ class ItemsController < ApplicationController
       else
         redirect_to root_path
       end
-    else
-      redirect_to root_path
+    else 
+      redirect_to user_path(current_user.id), alert: '既に購入された商品です'
     end
   end
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -105,7 +105,6 @@
                   = image_tag image, class: "meat"
                   -if item.buyer_id.present?
                     = render "items/sold-label-S"
-
               .newList--body
                 %h3.name
                   = item.name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -22,7 +22,8 @@
           円
           .itemBox__price_detail
             %span (税込)
-            %span 送料込み
+            %span.show-freight
+              = @item.freight
         .itemDetail 
           = @item.description
         .table

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,11 +92,10 @@
             = link_to "#" do
               = icon('fas', 'comment')
               コメントする
-      -unless @item.buyer_id.blank?
-        - if user_signed_in? && current_user.id == @item.user_id
-          .seller_function
-            = link_to '商品を編集する', edit_item_path(@item.id), class:"edit-item"
-            = link_to '商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "delete-item"
+      - if user_signed_in? && current_user.id == @item.user_id && @item.buyer_id.blank?
+        .seller_function
+          = link_to '商品を編集する', edit_item_path(@item.id), class:"edit-item"
+          = link_to '商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "delete-item"
     %ul.links 
       %li 
         = link_to "#", class:"link" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,7 +92,7 @@
             = link_to "#" do
               = icon('fas', 'comment')
               コメントする
-      -if @item.buyer_id.blank?
+      -unless @item.buyer_id.blank?
         - if user_signed_in? && current_user.id == @item.user_id
           .seller_function
             = link_to '商品を編集する', edit_item_path(@item.id), class:"edit-item"
@@ -112,23 +112,24 @@
       = link_to item_path, class: "relatedItems_bar" do
         = @item.category.name
         をもっと見る
-      = link_to item_path(@related_items.id), class:"productList" do
-        - @related_items.images.first(1).each do |image|
-          .relatedProduct
-            = image_tag @related_items.images.first, class:"productList_image"
-            -if @item.buyer_id.present?
-              = render "items/sold-label-S"
-            .productList_body
-              %h3.name 
-                = @related_items.name
-              .details
-                %ul 
-                  %li 
-                    = @related_items.price
-                    円
-                  %li 
-                    = icon('fas','star')
-                    = @item.favorites.count
-                (税込)
+        - @related_items.each do |item|
+          = link_to item_path(item.id), class:"productList" do
+            .relatedProduct
+              - item.images.first(1).each do |image|
+                = image_tag image, class:"productList_image"
+                -if item.buyer_id.present?
+                  = render "items/sold-label-S"
+                .productList_body
+                  %h3.name 
+                    = item.name
+                  .details
+                    %ul 
+                      %li 
+                        = item.price
+                        円
+                      %li 
+                        = icon('fas','star')
+                        = item.favorites.count
+                    (税込)
   = render "items/footer"
   = render "items/putup-btn" 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -91,10 +91,11 @@
             = link_to "#" do
               = icon('fas', 'comment')
               コメントする
-      - if user_signed_in? && current_user.id == @item.user_id
-        .seller_function
-          = link_to '商品を編集する', edit_item_path(@item.id), class:"edit-item"
-          = link_to '商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "delete-item"
+      -if @item.buyer_id.blank?
+        - if user_signed_in? && current_user.id == @item.user_id
+          .seller_function
+            = link_to '商品を編集する', edit_item_path(@item.id), class:"edit-item"
+            = link_to '商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "delete-item"
     %ul.links 
       %li 
         = link_to "#", class:"link" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -111,6 +111,7 @@
       = link_to item_path, class: "relatedItems_bar" do
         = @item.category.name
         をもっと見る
+      .relatedBox
         - @related_items.each do |item|
           = link_to item_path(item.id), class:"productList" do
             .relatedProduct


### PR DESCRIPTION
# What
購入済み商品の編集、削除の制限
商品情報の表示変更

# Why
購入後の商品情報の編集や削除が取引の信頼性を損なうため
ユーザーの関心のある商品を表示することが積極的な取引に繋がるため

GIF
<a href="https://gyazo.com/55ac26fe31738b72d97f25a0d8fb397b"><img src="https://i.gyazo.com/55ac26fe31738b72d97f25a0d8fb397b.gif" alt="Image from Gyazo" width="968"/></a>